### PR TITLE
Register post_type after registering taxonomy

### DIFF
--- a/plugin-name/includes/class-plugin-name-post_types.php
+++ b/plugin-name/includes/class-plugin-name-post_types.php
@@ -140,7 +140,6 @@ class Plugin_Name_Post_Types {
             $this->assign_capabilities( $args['capabilities'], $fields['custom_caps_users'] );
         }
 
-        register_post_type( $fields['slug'], $args );
 
         /**
          * Register Taxnonmies if any
@@ -155,6 +154,8 @@ class Plugin_Name_Post_Types {
             }
 
         }
+	    
+	register_post_type( $fields['slug'], $args );
 
     }
 


### PR DESCRIPTION
According to [this comment](https://developer.wordpress.org/reference/functions/register_taxonomy/#comment-2274) you have to register the CPT after registering the taxonomy io to get urls like this `%custom-post-type%/%taxonomy%/%taxonomy-term%`

I can confirm this is the case, don't know if it would cause other harm