### PR TITLE
Uncommented return from add_action_links method

### DIFF
--- a/plugin-name/tutorials/app_option_page_for_plugin.php
+++ b/plugin-name/tutorials/app_option_page_for_plugin.php
@@ -68,7 +68,8 @@ public function add_action_links( $links ) {
     // -- OR --
 
     // $settings_link = array( '<a href="' . admin_url( 'options-general.php?page=' . $this->plugin_name ) . '">' . __( 'Settings', $this->plugin_name ) . '</a>', );
-    // return array_merge(  $settings_link, $links );
+    
+    return array_merge(  $settings_link, $links );
 
 }
 


### PR DESCRIPTION
Return is required in order to show all the links.